### PR TITLE
Fix for JIRA IOTS-65

### DIFF
--- a/components/device-mgt-iot/org.wso2.carbon.device.mgt.iot/src/main/java/org/wso2/carbon/device/mgt/iot/config/devicetype/IotDeviceTypeConfigurationManager.java
+++ b/components/device-mgt-iot/org.wso2.carbon.device.mgt.iot/src/main/java/org/wso2/carbon/device/mgt/iot/config/devicetype/IotDeviceTypeConfigurationManager.java
@@ -88,13 +88,8 @@ public class IotDeviceTypeConfigurationManager {
 					iotDeviceTypeConfig.setApiApplicationName(iotDeviceTypeConfig.getType());
 				}
 				iotDeviceTypeConfigMap.put(iotDeviceTypeConfig.getType(), iotDeviceTypeConfig);
-
-
-			}
-			ApisAppClient.getInstance().setBase64EncodedConsumerKeyAndSecret(iotDeviceTypeConfigList);
-
-
-		} catch (Exception e) {
+            }
+        } catch (Exception e) {
 			String error = "Error occurred while initializing device configurations";
 			log.error(error);
 		}


### PR DESCRIPTION
All the device types which are installed in IOTS need to create an application on API Manager. Initial implementation it was done when device management service is being deployed. Now it is being done when deploying web app of relevant device type. There was a method in IoT device type configuration manager which try to create consumer key and secret for each device type. But that should be removed.