### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1334,7 +1334,7 @@
         <gcm.server.version>1.0.2</gcm.server.version>
         <!--<commons-json.version>2.0.0.wso2v1</commons-json.version>-->
         <commons-json.version>3.0.0.wso2v1</commons-json.version>
-        <commons-collections.version>3.2.1</commons-collections.version>
+        <commons-collections.version>3.2.2</commons-collections.version>
         <commons-configuration.version>1.8</commons-configuration.version>
         <httpclient.version>4.3.1.wso2v2</httpclient.version>
         <javaee-web-api.version>6.0</javaee-web-api.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/