### PR TITLE
Replacing the value of GLOBAL-STATE param with comma separated deviceId,deviceType

### DIFF
--- a/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.device-view/device-view.hbs
+++ b/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.device-view/device-view.hbs
@@ -339,7 +339,7 @@
                             </div>
                             <br/>
                             <a class="padding-left"
-                               href="{{portalUrl}}/portal/dashboards/geo-dashboard/?GLOBAL-STATE={{anchor}}">
+                               href="{{portalUrl}}/portal/dashboards/geo-dashboard/?GLOBAL-STATE={{deviceId}},{{deviceType}}">
                                 <span class="fw-stack">
                                     <i class="fw fw-circle-outline fw-stack-2x"></i>
                                     <i class="fw fw-map-location fw-stack-1x"></i>

--- a/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.device-view/device-view.js
+++ b/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.device-view/device-view.js
@@ -213,7 +213,7 @@ function onRequest(context) {
     deviceViewData["autoCompleteParams"] = autoCompleteParams;
 
     deviceViewData["portalUrl"] = devicemgtProps['portalURL'];
-    var anchor = { "device" : { "id" : deviceId, "type" : deviceType}};
-    deviceViewData["anchor"] = JSON.stringify(anchor);
+    deviceViewData["deviceId"] = deviceId;
+    deviceViewData["deviceType"] = deviceType;
     return deviceViewData;
 }


### PR DESCRIPTION
Earlier a JSON string was passed as the value for GLOBAL-STATE which caused 400 response when redirected to the portal. 