### PR TITLE
Fixing Android policy view and policy edit doesn't honor isCloud enabled param

### DIFF
--- a/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.policy-edit/public/templates/android-policy-edit.hbs
+++ b/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.policy-edit/public/templates/android-policy-edit.hbs
@@ -65,6 +65,7 @@
             <span id="vpn-ok" class="has-success status-icon hidden"><i class="fw fw-success"></i></span>
             <span id="vpn-error" class="has-error status-icon hidden"><i class="fw fw-error"></i></span>
         </a>
+        {{#unless iscloud}}
         <a href="javascript:void(0)" onclick="showAdvanceOperation('work-profile', this)">
              <span class="wr-hidden-operations-icon fw-stack">
                  <i class="fw fw-service fw-stack-2x"></i>
@@ -107,6 +108,7 @@
             <span id="cosu-whitelisted-applications-error" class="has-error status-icon hidden"><i
                     class="fw fw-error"></i></span>
         </a>
+        {{/unless}}
     </div>
 
     <div class="wr-hidden-operations-content col-lg-8">
@@ -302,6 +304,7 @@
                             </span>
                         </label>
                     </div>
+                    {{#unless iscloud}}
                     <div>
                         <ul class="message message-info">
                             <i class="icon fw fw-info"></i>
@@ -696,6 +699,7 @@
                         </label>
                     </div>
                     <br>
+                    {{/unless}}
                 </div>
             </div>
         </div>

--- a/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.policy-view/public/templates/android-policy-view.hbs
+++ b/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.policy-view/public/templates/android-policy-view.hbs
@@ -48,6 +48,7 @@
             <span id="wifi-ok" class="has-success status-icon hidden"><i class="fw fw-success"></i></span>
             <span id="wifi-error" class="has-error status-icon hidden"><i class="fw fw-error"></i></span>
         </a>
+        {{#unless iscloud}}
         <a href="javascript:void(0)" onclick="showAdvanceOperation('work-profile', this)">
              <span class="wr-hidden-operations-icon fw-stack">
                  <i class="fw fw-service fw-stack-2x"></i>
@@ -90,6 +91,7 @@
             <span id="cosu-whitelisted-applications-error" class="has-error status-icon hidden"><i
                     class="fw fw-error"></i></span>
         </a>
+        {{/unless}}
     </div>
     <div class="wr-hidden-operations-content col-lg-8">
         <!-- passcode-policy -->
@@ -287,6 +289,7 @@
                             </span>
                         </label>
                     </div>
+            {{#unless iscloud}}
                     <br><b>
                     Bellow restrictions will be applied on devices with Android version 5.0 Lollipop onwards only
                 </b>
@@ -701,6 +704,7 @@
                         </label>
                     </div>
                     <br>
+            {{/unless}}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This PR is depending on https://github.com/wso2/carbon-device-mgt/pull/710