### PR TITLE
Disabling maven-source-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1337,7 +1337,7 @@
                         </instructions>-->
                     </configuration>
                 </plugin>
-                <plugin>
+                <!--plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>2.1.2</version>
@@ -1350,7 +1350,7 @@
                             </goals>
                         </execution>
                     </executions>
-                </plugin>
+                </plugin-->
                 <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>
                     <version>2.2-beta-2</version>


### PR DESCRIPTION
Disabling maven-source-plugin to disable Jenkins release fail due to the large unnecessary source file generation.