### PR TITLE
Android Virtual Fire Alarm Initial query exception

### DIFF
--- a/components/device-types/virtual-fire-alarm-plugin/org.wso2.carbon.device.mgt.iot.virtualfirealarm.agent.advanced.impl/src/main/java/org/wso2/carbon/device/mgt/iot/virtualfirealarm/agent/advanced/communication/mqtt/FireAlarmMQTTCommunicator.java
+++ b/components/device-types/virtual-fire-alarm-plugin/org.wso2.carbon.device.mgt.iot.virtualfirealarm.agent.advanced.impl/src/main/java/org/wso2/carbon/device/mgt/iot/virtualfirealarm/agent/advanced/communication/mqtt/FireAlarmMQTTCommunicator.java
@@ -108,7 +108,6 @@ public class FireAlarmMQTTCommunicator extends MQTTTransportHandler {
     public void processIncomingMessage(MqttMessage message, String... messageParams) {
         final AgentManager agentManager = AgentManager.getInstance();
         String tenantDomain = agentManager.getAgentConfigs().getTenantDomain();
-        String deviceOwner = agentManager.getAgentConfigs().getDeviceOwner();
         String deviceID = agentManager.getAgentConfigs().getDeviceId();
         String receivedMessage;
         String replyMessage;
@@ -219,7 +218,7 @@ public class FireAlarmMQTTCommunicator extends MQTTTransportHandler {
 
                 } catch (TransportHandlerException e) {
                     log.warn(AgentConstants.LOG_APPENDER + "Data Publish attempt to topic - [" +
-                                     AgentConstants.MQTT_PUBLISH_TOPIC + "] failed for payload [" + message + "]");
+                            AgentConstants.MQTT_PUBLISH_TOPIC + "] failed for payload [" + message + "]");
                 } catch (AgentCoreOperationException e) {
                     log.warn(AgentConstants.LOG_APPENDER + "Preparing Secure payload failed", e);
                 }
@@ -255,7 +254,7 @@ public class FireAlarmMQTTCommunicator extends MQTTTransportHandler {
                             Thread.sleep(timeoutInterval);
                         } catch (InterruptedException e1) {
                             log.error(AgentConstants.LOG_APPENDER +
-                                              "MQTT-Terminator: Thread Sleep Interrupt Exception");
+                                    "MQTT-Terminator: Thread Sleep Interrupt Exception");
                         }
                     }
                 }

--- a/components/device-types/virtual-fire-alarm-plugin/org.wso2.carbon.device.mgt.iot.virtualfirealarm.agent.advanced.impl/src/main/resources/cep_query.txt
+++ b/components/device-types/virtual-fire-alarm-plugin/org.wso2.carbon.device.mgt.iot.virtualfirealarm.agent.advanced.impl/src/main/resources/cep_query.txt
@@ -1,5 +1,5 @@
 define stream fireAlarmEventStream (deviceID string, temp int);
-from fireAlarmEventStream#window.time(7886776 sec)
+from fireAlarmEventStream#window.time(10 sec)
 select deviceID, max(temp) as maxValue
 group by deviceID
 insert into analyzeStream for expired-events;

--- a/components/device-types/virtual-fire-alarm-plugin/org.wso2.carbon.device.mgt.iot.virtualfirealarm.api/src/main/java/org/wso2/carbon/device/mgt/iot/virtualfirealarm/service/impl/VirtualFireAlarmServiceImpl.java
+++ b/components/device-types/virtual-fire-alarm-plugin/org.wso2.carbon.device.mgt.iot.virtualfirealarm.api/src/main/java/org/wso2/carbon/device/mgt/iot/virtualfirealarm/service/impl/VirtualFireAlarmServiceImpl.java
@@ -103,7 +103,6 @@ public class VirtualFireAlarmServiceImpl implements VirtualFireAlarmService {
             commandOp.setPayLoad(actualMessage);
 
             Properties props = new Properties();
-            props.setProperty(VirtualFireAlarmConstants.MQTT_ADAPTER_TOPIC_PROPERTY_NAME, publishTopic);
             props.setProperty(VirtualFireAlarmConstants.CLIENT_JID_PROPERTY_KEY, deviceId + "@" + XmppConfig
                     .getInstance().getServerName());
             props.setProperty(VirtualFireAlarmConstants.SUBJECT_PROPERTY_KEY, "CONTROL-REQUEST");


### PR DESCRIPTION
when starting virtual fire alarm, initially exception is thrown when there is no query in cep.qry file.