### PR TITLE
Updated carbon-device-mgt version and a minor fix

### DIFF
--- a/components/device-types/raspberrypi-plugin/org.wso2.carbon.device.mgt.iot.raspberrypi.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.raspberrypi.type-view/type-view.hbs
+++ b/components/device-types/raspberrypi-plugin/org.wso2.carbon.device.mgt.iot.raspberrypi.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.raspberrypi.type-view/type-view.hbs
@@ -94,7 +94,7 @@
                             <a class="btn btn-operations" onclick="downloadAgent()">Download Now</a>
 
                             <a href="#" id="download-device-download-link"
-                               class="btn btn-operations"> Copy Link
+                               class="btn btn-operations hidden"> Copy Link
                             </a>
 
                         </div>

--- a/pom.xml
+++ b/pom.xml
@@ -1141,7 +1141,7 @@
         <javax.ws.rs.version>1.1.1</javax.ws.rs.version>
 
         <!-- Carbon Device Management -->
-        <carbon.devicemgt.version>3.0.45</carbon.devicemgt.version>
+        <carbon.devicemgt.version>3.0.57</carbon.devicemgt.version>
         <carbon.devicemgt.version.range>[3.0.0, 4.0.0)</carbon.devicemgt.version.range>
 
         <!-- Carbon App Management -->


### PR DESCRIPTION
Minor fix-This will temporarily hide the 'copy link' button on Raspberry Pi device type