### PR TITLE
Truncating longer versions in Application Listing view

### DIFF
--- a/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.device-view/public/templates/applications-list.hbs
+++ b/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.device-view/public/templates/applications-list.hbs
@@ -3,7 +3,7 @@
       <img src="">
       <div class="app-info">
           <h4 title="{{name}}">{{name}}</h4>
-          <p>v{{version}}</p>
+          <p class="truncate">v{{version}}</p>
       </div>
   </div>
 {{/each}}

--- a/components/mobile-plugins/windows-plugin/org.wso2.carbon.device.mgt.mobile.windows.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.windows.device-view/public/templates/applications-list.hbs
+++ b/components/mobile-plugins/windows-plugin/org.wso2.carbon.device.mgt.mobile.windows.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.windows.device-view/public/templates/applications-list.hbs
@@ -3,7 +3,7 @@
       <img src="">
       <div class="app-info">
           <h4 title="{{name}}">{{name}}</h4>
-          <p>v{{version}}</p>
+          <p class="truncate">v{{version}}</p>
       </div>
   </div>
 {{/each}}


### PR DESCRIPTION
This commit truncates the version attribute of the application if the version is longer to fit the application view container.

fixes wso2/product-iots#1311