### PR TITLE
clustering of devices based on geo location

### DIFF
--- a/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.api/src/test/java/org/wso2/carbon/mdm/services/android/mocks/DeviceManagementProviderServiceMock.java
+++ b/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.api/src/test/java/org/wso2/carbon/mdm/services/android/mocks/DeviceManagementProviderServiceMock.java
@@ -38,6 +38,8 @@ import org.wso2.carbon.device.mgt.common.pull.notification.PullNotificationExecu
 import org.wso2.carbon.device.mgt.common.push.notification.NotificationStrategy;
 import org.wso2.carbon.device.mgt.common.spi.DeviceManagementService;
 import org.wso2.carbon.device.mgt.core.dto.DeviceType;
+import org.wso2.carbon.device.mgt.core.geo.GeoCluster;
+import org.wso2.carbon.device.mgt.core.geo.geoHash.GeoCoordinate;
 import org.wso2.carbon.device.mgt.core.service.DeviceManagementProviderService;
 import org.wso2.carbon.device.mgt.core.service.EmailMetaInfo;
 import org.wso2.carbon.mdm.services.android.utils.TestUtils;
@@ -499,6 +501,11 @@ public class DeviceManagementProviderServiceMock implements DeviceManagementProv
 
     @Override
     public List<Integer> getDeviceEnrolledTenants() throws DeviceManagementException {
+        return null;
+    }
+
+    @Override
+    public List<GeoCluster> findGeoClusters(GeoCoordinate geoCoordinate, GeoCoordinate geoCoordinate1, int i) throws DeviceManagementException {
         return null;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1215,7 +1215,7 @@
         <javax.ws.rs.version>1.1.1</javax.ws.rs.version>
 
         <!-- Carbon Device Management -->
-        <carbon.devicemgt.version>3.0.176</carbon.devicemgt.version>
+        <carbon.devicemgt.version>3.0.179-SNAPSHOT</carbon.devicemgt.version>
         <carbon.devicemgt.version.range>[3.0.0, 4.0.0)</carbon.devicemgt.version.range>
 
         <!-- Carbon App Management -->

--- a/pom.xml
+++ b/pom.xml
@@ -1215,7 +1215,7 @@
         <javax.ws.rs.version>1.1.1</javax.ws.rs.version>
 
         <!-- Carbon Device Management -->
-        <carbon.devicemgt.version>3.0.179-SNAPSHOT</carbon.devicemgt.version>
+        <carbon.devicemgt.version>3.0.181-SNAPSHOT</carbon.devicemgt.version>
         <carbon.devicemgt.version.range>[3.0.0, 4.0.0)</carbon.devicemgt.version.range>
 
         <!-- Carbon App Management -->

--- a/pom.xml
+++ b/pom.xml
@@ -1215,7 +1215,7 @@
         <javax.ws.rs.version>1.1.1</javax.ws.rs.version>
 
         <!-- Carbon Device Management -->
-        <carbon.devicemgt.version>3.0.181-SNAPSHOT</carbon.devicemgt.version>
+        <carbon.devicemgt.version>3.0.182</carbon.devicemgt.version>
         <carbon.devicemgt.version.range>[3.0.0, 4.0.0)</carbon.devicemgt.version.range>
 
         <!-- Carbon App Management -->


### PR DESCRIPTION
## Purpose
Changes which are needed to be done in the carbon-device-mgt plugins in order to support clustering of devices based on geo location when showing in a map.