### PR TITLE
Fixed wso2/product-iots#1528

### DIFF
--- a/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.type-view/private/config.json
+++ b/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.type-view/private/config.json
@@ -4,7 +4,7 @@
         "virtualLabel": "virtual Android",
         "category": "hybrid",
         "analyticsEnabled": "false",
-        "groupingEnabled": "false",
+        "groupingEnabled": "true",
         "scopes" : [
             "perm:android:file-transfer",
             "perm:android:enroll",


### PR DESCRIPTION
## Purpose
> The purpose of this fix is to enable device grouping capabilities to the Android device type.

## Approach
> Modified available configuration to enable grouping for Android device type.

<img width="1920" alt="screen shot 2017-12-14 at 1 04 19 pm" src="https://user-images.githubusercontent.com/11870191/33980712-0bb801a0-e0d0-11e7-8b9c-0199e829e700.png">
