### PR TITLE
Bumping carbon-device-mgt version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1215,7 +1215,7 @@
         <javax.ws.rs.version>1.1.1</javax.ws.rs.version>
 
         <!-- Carbon Device Management -->
-        <carbon.devicemgt.version>3.0.198</carbon.devicemgt.version>
+        <carbon.devicemgt.version>3.0.199</carbon.devicemgt.version>
         <carbon.devicemgt.version.range>[3.0.0, 4.0.0)</carbon.devicemgt.version.range>
 
         <!-- Carbon App Management -->


### PR DESCRIPTION
## Purpose
> Bumping carbon-device-mgt version and adding v3.1.27 of the android-agent for update relaese.