### PR TITLE
Device information in device view are incorrect and also needs tooltips

### DIFF
--- a/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.device-view/device-view.hbs
+++ b/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.device-view/device-view.hbs
@@ -55,7 +55,7 @@
           <div class="vital-strip">
             {{#if device.deviceInfoAvailable}}
               {{#if device.BatteryLevel}}
-                <p title="Total used /Total available storage" data-toggle="tooltip">
+                <p title="Battery level percentage" data-toggle="tooltip">
                     <i class="icon fw fw-battery fw-2x"></i>
                     <span>{{device.BatteryLevel.value}}%</span>
                 </p>
@@ -67,17 +67,17 @@
                 </p>
               {{/if}}
               {{#if device.internalMemory}}
-                <p title="Total used /Total available internal storage" data-toggle="tooltip">
+                <p title="Free space / Total available internal storage" data-toggle="tooltip">
                     <i class="icon fw fw-hdd fw-2x fw-rotate-90"></i>
                     <span>{{device.internalMemory.usage}}</span>
-                    <span class="memory-amt">GB Used/{{device.internalMemory.total}}GB Total</span>
+                    <span class="memory-amt">GB Free/{{device.internalMemory.total}}GB Total</span>
                 </p>
               {{/if}}
               {{#if device.externalMemory}}
-                <p title="Total used /Total available external storage" data-toggle="tooltip">
+                <p title="Free space / Total available external storage" data-toggle="tooltip">
                     <i class="icon fw fw-usb-drive fw-2x"></i>
                     <span>{{device.externalMemory.usage}}</span>
-                    <span class="memory-amt">GB Used/{{device.externalMemory.total}}GB Total</span>
+                    <span class="memory-amt">GB Free/{{device.externalMemory.total}}GB Total</span>
                 </p>
               {{/if}}
             {{else}}

--- a/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.device-view/device-view.hbs
+++ b/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.device-view/device-view.hbs
@@ -55,22 +55,33 @@
           <div class="vital-strip">
             {{#if device.deviceInfoAvailable}}
               {{#if device.BatteryLevel}}
-                <p><i class="icon fw fw-battery fw-2x"></i> <span>{{device.BatteryLevel.value}}%</span></p>
+                <p title="Total used /Total available storage" data-toggle="tooltip">
+                    <i class="icon fw fw-battery fw-2x"></i>
+                    <span>{{device.BatteryLevel.value}}%</span>
+                </p>
               {{/if}}
               {{#if device.ramUsage}}
-                <p><i class="icon fw fw-hardware fw-2x fw-rotate-90"></i> <span>{{device.ramUsage.value}}%</span></p>
+                <p title="RAM usage percentage" data-toggle="tooltip">
+                    <i class="icon fw fw-hardware fw-2x fw-rotate-90"></i>
+                    <span>{{device.ramUsage.value}}%</span>
+                </p>
               {{/if}}
               {{#if device.internalMemory}}
-                <p><i class="icon fw fw-hdd fw-2x fw-rotate-90"></i> <span>{{device.internalMemory.usage}}</span>
-                  <span class="memory-amt">GB/{{device.internalMemory.total}}GB</span></p>
+                <p title="Total used /Total available internal storage" data-toggle="tooltip">
+                    <i class="icon fw fw-hdd fw-2x fw-rotate-90"></i>
+                    <span>{{device.internalMemory.usage}}</span>
+                    <span class="memory-amt">GB Used/{{device.internalMemory.total}}GB Total</span>
+                </p>
               {{/if}}
               {{#if device.externalMemory}}
-                <p><i class="icon fw fw-usb-drive fw-2x"></i> <span>{{device.externalMemory.usage}}</span>
-                  <span class="memory-amt">GB/{{device.externalMemory.total}}GB</span></p>
+                <p title="Total used /Total available external storage" data-toggle="tooltip">
+                    <i class="icon fw fw-usb-drive fw-2x"></i>
+                    <span>{{device.externalMemory.usage}}</span>
+                    <span class="memory-amt">GB Used/{{device.externalMemory.total}}GB Total</span>
+                </p>
               {{/if}}
             {{else}}
-              <p>Battery, RAM and Storage related information are not
-              available yet.</p>
+              <p>Battery, RAM and Storage related information are not available yet.</p>
             {{/if}}
           </div>
         {{/zone}}

--- a/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.device-view/device-view.js
+++ b/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.device-view/device-view.js
@@ -163,13 +163,12 @@ function onRequest(context) {
                 }
 
                 viewModel["externalMemory"] = {};
-                viewModel["externalMemory"]["total"] = replaceNaNVal(Math.
-                    round(filteredDeviceData["latestDeviceInfo"]["externalTotalMemory"] * 100) / 100);
                 if (filteredDeviceData["latestDeviceInfo"]["externalTotalMemory"] != 0) {
+                    viewModel["externalMemory"]["total"] = replaceNaNVal(Math.round
+                    (filteredDeviceData["latestDeviceInfo"]["externalTotalMemory"] * 100) / 100);
                     viewModel["externalMemory"]["usage"] = replaceNaNVal(Math.
-                        round((filteredDeviceData["latestDeviceInfo"]["externalTotalMemory"] -
-                            filteredDeviceData["latestDeviceInfo"]["externalAvailableMemory"])
-                            / filteredDeviceData["latestDeviceInfo"]["externalTotalMemory"] * 10000) / 100);
+                    round((filteredDeviceData["latestDeviceInfo"]["externalTotalMemory"] -
+                    filteredDeviceData["latestDeviceInfo"]["externalAvailableMemory"])* 100) /100);
                 } else {
                     viewModel["externalMemory"]["usage"] = 0;
                 }

--- a/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.device-view/device-view.js
+++ b/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.device-view/device-view.js
@@ -153,11 +153,11 @@ function onRequest(context) {
                 }
 
                 viewModel["internalMemory"] = {};
-                viewModel["internalMemory"]["total"] = replaceNaNVal(Math.
-                    round(filteredDeviceData["latestDeviceInfo"]["internalTotalMemory"] * 100) / 100);
                 if (filteredDeviceData["latestDeviceInfo"]["internalTotalMemory"] != 0) {
-                    viewModel["internalMemory"]["usage"] = replaceNaNVal(Math.round((filteredDeviceData["latestDeviceInfo"]["internalTotalMemory"] -
-                        filteredDeviceData["latestDeviceInfo"]["internalAvailableMemory"]) * 100) / 100);
+                    viewModel["internalMemory"]["total"] = replaceNaNVal(Math.round
+                    (filteredDeviceData["latestDeviceInfo"]["internalTotalMemory"] * 100) / 100);
+                    viewModel["internalMemory"]["usage"] = replaceNaNVal(Math.round
+                    (filteredDeviceData["latestDeviceInfo"]["internalAvailableMemory"] * 100) / 100);
                 } else {
                     viewModel["internalMemory"]["usage"] = 0;
                 }
@@ -167,8 +167,8 @@ function onRequest(context) {
                     viewModel["externalMemory"]["total"] = replaceNaNVal(Math.round
                     (filteredDeviceData["latestDeviceInfo"]["externalTotalMemory"] * 100) / 100);
                     viewModel["externalMemory"]["usage"] = replaceNaNVal(Math.
-                    round((filteredDeviceData["latestDeviceInfo"]["externalTotalMemory"] -
-                    filteredDeviceData["latestDeviceInfo"]["externalAvailableMemory"])* 100) /100);
+                    round(filteredDeviceData["latestDeviceInfo"]["externalAvailableMemory"]* 100)
+                    /100);
                 } else {
                     viewModel["externalMemory"]["usage"] = 0;
                 }


### PR DESCRIPTION
## Purpose
Improving the consistency of the device information displayed on the device view page of Android devices. Currently, not tooltips are provided for device details and the values displayed are incorrect.

## Goals
Add tooltip text for device details and fix the values displayed since they are incorrect.

## Approach
Add tooltips and fix the calculation logic of the device storage space.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A, this is an improvement in the backend code.

## Marketing
N/A

## Automation tests
covered in existing code

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
https://github.com/wso2/carbon-devicemgt-proprietary-plugins/pull/188

## Migrations (if applicable)
N/A

## Test environment
JDK 1.8
MacOS 10.13, Android 7.0
 
## Learning
N/A

