### PR TITLE
Updating the carbon-device-mgt version

### DIFF
--- a/components/extensions/siddhi-extensions/org.wso2.extension.siddhi.device/src/test/java/org/wso2/extension/siddhi/device/test/util/TestDeviceManagementService.java
+++ b/components/extensions/siddhi-extensions/org.wso2.extension.siddhi.device/src/test/java/org/wso2/extension/siddhi/device/test/util/TestDeviceManagementService.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.device.mgt.common.MonitoringOperation;
 import org.wso2.carbon.device.mgt.common.OperationMonitoringTaskConfig;
 import org.wso2.carbon.device.mgt.common.ProvisioningConfig;
 import org.wso2.carbon.device.mgt.common.app.mgt.ApplicationManager;
+import org.wso2.carbon.device.mgt.common.general.GeneralConfig;
 import org.wso2.carbon.device.mgt.common.policy.mgt.PolicyMonitoringManager;
 import org.wso2.carbon.device.mgt.common.pull.notification.PullNotificationSubscriber;
 import org.wso2.carbon.device.mgt.common.push.notification.PushNotificationConfig;
@@ -106,6 +107,11 @@ public class TestDeviceManagementService implements DeviceManagementService {
 
     @Override
     public DeviceStatusTaskPluginConfig getDeviceStatusTaskPluginConfig() {
+        return null;
+    }
+
+    @Override
+    public GeneralConfig getGeneralConfig() {
         return null;
     }
 }

--- a/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.api/src/test/java/org/wso2/carbon/mdm/services/android/mocks/DeviceManagementProviderServiceMock.java
+++ b/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.api/src/test/java/org/wso2/carbon/mdm/services/android/mocks/DeviceManagementProviderServiceMock.java
@@ -347,6 +347,11 @@ public class DeviceManagementProviderServiceMock implements DeviceManagementProv
     }
 
     @Override
+    public List<String> getPolicyMonitoringEnableDeviceTypes() throws DeviceManagementException {
+        return null;
+    }
+
+    @Override
     public boolean updateDeviceInfo(DeviceIdentifier deviceIdentifier, Device device) throws DeviceManagementException {
         return false;
     }
@@ -438,6 +443,11 @@ public class DeviceManagementProviderServiceMock implements DeviceManagementProv
 
     @Override
     public Activity getOperationByActivityId(String s) throws OperationManagementException {
+        return null;
+    }
+
+    @Override
+    public List<Activity> getOperationByActivityIds(List<String> list) throws OperationManagementException {
         return null;
     }
 

--- a/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.v09.api/src/test/java/org/wso2/carbon/mdm/services/android/mocks/DeviceManagementProviderServiceMock.java
+++ b/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.v09.api/src/test/java/org/wso2/carbon/mdm/services/android/mocks/DeviceManagementProviderServiceMock.java
@@ -347,6 +347,11 @@ public class DeviceManagementProviderServiceMock implements DeviceManagementProv
     }
 
     @Override
+    public List<String> getPolicyMonitoringEnableDeviceTypes() throws DeviceManagementException {
+        return null;
+    }
+
+    @Override
     public boolean updateDeviceInfo(DeviceIdentifier deviceIdentifier, Device device) throws DeviceManagementException {
         return false;
     }
@@ -438,6 +443,11 @@ public class DeviceManagementProviderServiceMock implements DeviceManagementProv
 
     @Override
     public Activity getOperationByActivityId(String s) throws OperationManagementException {
+        return null;
+    }
+
+    @Override
+    public List<Activity> getOperationByActivityIds(List<String> list) throws OperationManagementException {
         return null;
     }
 

--- a/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android/src/main/java/org/wso2/carbon/device/mgt/mobile/android/impl/AndroidDeviceManagementService.java
+++ b/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android/src/main/java/org/wso2/carbon/device/mgt/mobile/android/impl/AndroidDeviceManagementService.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.device.mgt.common.DeviceStatusTaskPluginConfig;
 import org.wso2.carbon.device.mgt.common.app.mgt.ApplicationManager;
 import org.wso2.carbon.device.mgt.common.configuration.mgt.ConfigurationEntry;
 import org.wso2.carbon.device.mgt.common.configuration.mgt.PlatformConfiguration;
+import org.wso2.carbon.device.mgt.common.general.GeneralConfig;
 import org.wso2.carbon.device.mgt.common.policy.mgt.PolicyMonitoringManager;
 import org.wso2.carbon.device.mgt.common.pull.notification.PullNotificationSubscriber;
 import org.wso2.carbon.device.mgt.common.push.notification.PushNotificationConfig;
@@ -129,6 +130,11 @@ public class AndroidDeviceManagementService implements DeviceManagementService {
 
     @Override
     public DeviceStatusTaskPluginConfig getDeviceStatusTaskPluginConfig() {
+        return null;
+    }
+
+    @Override
+    public GeneralConfig getGeneralConfig() {
         return null;
     }
 

--- a/components/mobile-plugins/windows-plugin/org.wso2.carbon.device.mgt.mobile.windows/src/main/java/org/wso2/carbon/device/mgt/mobile/windows/impl/WindowsDeviceManagementService.java
+++ b/components/mobile-plugins/windows-plugin/org.wso2.carbon.device.mgt.mobile.windows/src/main/java/org/wso2/carbon/device/mgt/mobile/windows/impl/WindowsDeviceManagementService.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.device.mgt.mobile.windows.impl;
 
 import org.wso2.carbon.device.mgt.common.*;
 import org.wso2.carbon.device.mgt.common.app.mgt.ApplicationManager;
+import org.wso2.carbon.device.mgt.common.general.GeneralConfig;
 import org.wso2.carbon.device.mgt.common.policy.mgt.PolicyMonitoringManager;
 import org.wso2.carbon.device.mgt.common.pull.notification.PullNotificationSubscriber;
 import org.wso2.carbon.device.mgt.common.push.notification.PushNotificationConfig;
@@ -88,6 +89,11 @@ public class WindowsDeviceManagementService implements DeviceManagementService {
 
     @Override
     public DeviceStatusTaskPluginConfig getDeviceStatusTaskPluginConfig() {
+        return null;
+    }
+
+    @Override
+    public GeneralConfig getGeneralConfig() {
         return null;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1215,7 +1215,7 @@
         <javax.ws.rs.version>1.1.1</javax.ws.rs.version>
 
         <!-- Carbon Device Management -->
-        <carbon.devicemgt.version>3.0.199</carbon.devicemgt.version>
+        <carbon.devicemgt.version>3.0.207</carbon.devicemgt.version>
         <carbon.devicemgt.version.range>[3.0.0, 4.0.0)</carbon.devicemgt.version.range>
 
         <!-- Carbon App Management -->


### PR DESCRIPTION
## Purpose
This upgrade has API changes due to fixes to the policy monitoring

## Goals
Updating the device-mgt version

## Approach
NA

## User stories
NA

## Release note
NA

## Documentation
NA

## Training
NA

## Certification
NA

## Marketing
NA

## Automation tests
NA

## Security checks
Yes

## Samples
NA

## Related PRs
https://github.com/wso2/carbon-device-mgt/pull/1162

## Migrations (if applicable)
NA

## Test environment
NA
 
## Learning
NA