### PR TITLE
Implemented operation response publishing to analytics

### DIFF
--- a/components/analytics/iot-analytics/org.wso2.carbon.device.mgt.iot.analytics/src/main/resources/carbonapps/device_analytics/WSO2IoT-DeviceInfo-Receiver_1.0.0/artifact.xml
+++ b/components/analytics/iot-analytics/org.wso2.carbon.device.mgt.iot.analytics/src/main/resources/carbonapps/device_analytics/WSO2IoT-DeviceInfo-Receiver_1.0.0/artifact.xml
@@ -16,6 +16,6 @@
   ~ under the License.
   -->
 
-<artifact name="WSO2IoT-DeviceInfo-Receiver" version="1.0.0" type="event/receiver" serverRole="GeoDashboard">
+<artifact name="WSO2IoT-DeviceInfo-Receiver" version="1.0.0" type="event/receiver" serverRole="DataAnalyticsServer">
     <file>WSO2IoT-DeviceInfo-Receiver_1.0.0.xml</file>
 </artifact>

--- a/components/analytics/iot-analytics/org.wso2.carbon.device.mgt.iot.analytics/src/main/resources/carbonapps/device_analytics/WSO2IoT-DeviceOperation-Publisher_1.0.0/artifact.xml
+++ b/components/analytics/iot-analytics/org.wso2.carbon.device.mgt.iot.analytics/src/main/resources/carbonapps/device_analytics/WSO2IoT-DeviceOperation-Publisher_1.0.0/artifact.xml
@@ -16,6 +16,7 @@
   ~ under the License.
   -->
 
-<artifact name="WSO2IoT-DeviceOperation-Publisher" version="1.0.0" type="event/publisher" serverRole="GeoDashboard">
+<artifact name="WSO2IoT-DeviceOperation-Publisher" version="1.0.0" type="event/publisher"
+          serverRole="DataAnalyticsServer">
     <file>WSO2IoT-DeviceOperation-Publisher_1.0.0.xml</file>
 </artifact>

--- a/components/analytics/iot-analytics/org.wso2.carbon.device.mgt.iot.analytics/src/main/resources/carbonapps/device_analytics/WSO2IoT-OperationResponse-Receiver_1.0.0/WSO2IoT-OperationResponse-Receiver_1.0.0.xml
+++ b/components/analytics/iot-analytics/org.wso2.carbon.device.mgt.iot.analytics/src/main/resources/carbonapps/device_analytics/WSO2IoT-OperationResponse-Receiver_1.0.0/WSO2IoT-OperationResponse-Receiver_1.0.0.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<eventReceiver name="WSO2IoT-OperationResponse-Receiver" xmlns="http://wso2.org/carbon/eventreceiver">
+    <from eventAdapterType="iot-event">
+        <property name="events.duplicated.in.cluster">false</property>
+    </from>
+    <mapping customMapping="disable" type="wso2event"/>
+    <to streamName="org.wso2.iot.OperationResponseStream" version="1.0.0"/>
+</eventReceiver>

--- a/components/analytics/iot-analytics/org.wso2.carbon.device.mgt.iot.analytics/src/main/resources/carbonapps/device_analytics/WSO2IoT-OperationResponse-Receiver_1.0.0/artifact.xml
+++ b/components/analytics/iot-analytics/org.wso2.carbon.device.mgt.iot.analytics/src/main/resources/carbonapps/device_analytics/WSO2IoT-OperationResponse-Receiver_1.0.0/artifact.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?><!--
-  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
   ~
   ~ WSO2 Inc. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
   ~ in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~   http://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing,
   ~ software distributed under the License is distributed on an
@@ -16,6 +16,7 @@
   ~ under the License.
   -->
 
-<artifact name="org.wso2.iot.operation" version="1.0.0" type="event/stream" serverRole="DataAnalyticsServer">
-    <file>org.wso2.iot.operation_1.0.0.json</file>
+<artifact name="WSO2IoT-OperationResponse-Receiver" version="1.0.0" type="event/receiver"
+          serverRole="DataAnalyticsServer">
+    <file>WSO2IoT-OperationResponse-Receiver_1.0.0.xml</file>
 </artifact>

--- a/components/analytics/iot-analytics/org.wso2.carbon.device.mgt.iot.analytics/src/main/resources/carbonapps/device_analytics/artifacts.xml
+++ b/components/analytics/iot-analytics/org.wso2.carbon.device.mgt.iot.analytics/src/main/resources/carbonapps/device_analytics/artifacts.xml
@@ -22,9 +22,13 @@
         <!-- CEP Artifacts -->
         <dependency artifact="org.wso2.iot.DeviceInfoStream" version="1.0.0" include="true"
                     serverRole="DataAnalyticsServer"/>
+        <dependency artifact="org.wso2.iot.OperationResponseStream" version="1.0.0" include="true"
+                    serverRole="DataAnalyticsServer"/>
         <dependency artifact="org.wso2.iot.operation" version="1.0.0" include="true"
                     serverRole="DataAnalyticsServer"/>
         <dependency artifact="WSO2IoT-DeviceInfo-Receiver" version="1.0.0" include="true"
+                    serverRole="DataAnalyticsServer"/>
+        <dependency artifact="WSO2IoT-OperationResponse-Receiver" version="1.0.0" include="true"
                     serverRole="DataAnalyticsServer"/>
         <dependency artifact="WSO2IoT-DeviceOperation-Publisher" version="1.0.0" include="true"
                     serverRole="DataAnalyticsServer"/>

--- a/components/analytics/iot-analytics/org.wso2.carbon.device.mgt.iot.analytics/src/main/resources/carbonapps/device_analytics/org.wso2.iot.DeviceInfoStream_1.0.0/artifact.xml
+++ b/components/analytics/iot-analytics/org.wso2.carbon.device.mgt.iot.analytics/src/main/resources/carbonapps/device_analytics/org.wso2.iot.DeviceInfoStream_1.0.0/artifact.xml
@@ -16,6 +16,6 @@
   ~ under the License.
   -->
 
-<artifact name="org.wso2.iot.DeviceInfoStream" version="1.0.0" type="event/stream" serverRole="GeoDashboard">
+<artifact name="org.wso2.iot.DeviceInfoStream" version="1.0.0" type="event/stream" serverRole="DataAnalyticsServer">
     <file>org.wso2.iot.DeviceInfoStream_1.0.0.json</file>
 </artifact>

--- a/components/analytics/iot-analytics/org.wso2.carbon.device.mgt.iot.analytics/src/main/resources/carbonapps/device_analytics/org.wso2.iot.OperationResponseStream_1.0.0/artifact.xml
+++ b/components/analytics/iot-analytics/org.wso2.carbon.device.mgt.iot.analytics/src/main/resources/carbonapps/device_analytics/org.wso2.iot.OperationResponseStream_1.0.0/artifact.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?><!--
-  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
   ~
   ~ WSO2 Inc. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
   ~ in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~   http://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing,
   ~ software distributed under the License is distributed on an
@@ -16,6 +16,7 @@
   ~ under the License.
   -->
 
-<artifact name="org.wso2.iot.operation" version="1.0.0" type="event/stream" serverRole="DataAnalyticsServer">
-    <file>org.wso2.iot.operation_1.0.0.json</file>
+<artifact name="org.wso2.iot.OperationResponseStream" version="1.0.0" type="event/stream"
+          serverRole="DataAnalyticsServer">
+    <file>org.wso2.iot.OperationResponseStream_1.0.0.json</file>
 </artifact>

--- a/components/analytics/iot-analytics/org.wso2.carbon.device.mgt.iot.analytics/src/main/resources/carbonapps/device_analytics/org.wso2.iot.OperationResponseStream_1.0.0/org.wso2.iot.OperationResponseStream_1.0.0.json
+++ b/components/analytics/iot-analytics/org.wso2.carbon.device.mgt.iot.analytics/src/main/resources/carbonapps/device_analytics/org.wso2.iot.OperationResponseStream_1.0.0/org.wso2.iot.OperationResponseStream_1.0.0.json
@@ -1,0 +1,42 @@
+{
+  "name": "org.wso2.iot.OperationResponseStream",
+  "version": "1.0.0",
+  "nickName": "",
+  "description": "IoT Server Operation Response Stream",
+  "metaData": [
+    {
+      "name": "deviceId",
+      "type": "STRING"
+    },
+    {
+      "name": "deviceType",
+      "type": "STRING"
+    }
+  ],
+  "payloadData": [
+    {
+      "name": "timeStamp",
+      "type": "LONG"
+    },
+    {
+      "name": "id",
+      "type": "INT"
+    },
+    {
+      "name": "code",
+      "type": "STRING"
+    },
+    {
+      "name": "type",
+      "type": "STRING"
+    },
+    {
+      "name": "status",
+      "type": "STRING"
+    },
+    {
+      "name": "response",
+      "type": "STRING"
+    }
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1215,7 +1215,7 @@
         <javax.ws.rs.version>1.1.1</javax.ws.rs.version>
 
         <!-- Carbon Device Management -->
-        <carbon.devicemgt.version>3.0.208</carbon.devicemgt.version>
+        <carbon.devicemgt.version>3.0.213</carbon.devicemgt.version>
         <carbon.devicemgt.version.range>[3.0.0, 4.0.0)</carbon.devicemgt.version.range>
 
         <!-- Carbon App Management -->

--- a/pom.xml
+++ b/pom.xml
@@ -1215,7 +1215,7 @@
         <javax.ws.rs.version>1.1.1</javax.ws.rs.version>
 
         <!-- Carbon Device Management -->
-        <carbon.devicemgt.version>3.0.213</carbon.devicemgt.version>
+        <carbon.devicemgt.version>3.0.215</carbon.devicemgt.version>
         <carbon.devicemgt.version.range>[3.0.0, 4.0.0)</carbon.devicemgt.version.range>
 
         <!-- Carbon App Management -->


### PR DESCRIPTION
## Purpose
> This improvement done to publish operation responses to Analytics. This improvement used added config in PR https://github.com/wso2/carbon-device-mgt/pull/1163 to determine required operation responses that needed to be published to analytics.

## Goals
> Publish responses of specified operations to analytics.

## Approach
> Intercept operation update method in the device management core and publish operation response as event to the analytics. Implement event receiver and corresponding event stream in analytics to receive events from IoT core.

## User stories
> User can enable PublishOperationResponse via cdm-config.xml and IoT core will publish operation response events to Analytics. Optionally user can specify required operation responses to be published or select all operation responses to be published.

## Release note
> Added capability to publish configurable set of operation responses to Analytics from IoT core.

## Documentation
> https://docs.wso2.com/display/IOTS320/Publishing+Operation+response+to+Analytics

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > 55%

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
- https://github.com/wso2/carbon-device-mgt/pull/1163
- https://github.com/wso2/carbon-device-mgt/pull/1169

## Migrations (if applicable)
> N/A

## Test environment
> Fedora 23 Linux 4.8.13-100.fc23.x86_64, Oracle JDK 1.8.0_91-b14, H2
 
## Learning
> N/A