### PR TITLE
Fixing the error in event publishing

### DIFF
--- a/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.api/src/main/java/org/wso2/carbon/mdm/services/android/services/impl/EventReceiverServiceImpl.java
+++ b/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.api/src/main/java/org/wso2/carbon/mdm/services/android/services/impl/EventReceiverServiceImpl.java
@@ -106,9 +106,12 @@ public class EventReceiverServiceImpl implements EventReceiverService {
                 message.setResponseCode("Event is published successfully.");
                 return Response.status(Response.Status.CREATED).entity(message).build();
             } else {
+                log.warn("Error occurred while trying to publish the event. This could be due to unavailability " +
+                        "of the publishing service. Please make sure that analytics server is running and accessible by " +
+                        "this server");
                 throw new UnexpectedServerErrorException(
-                        new ErrorResponse.ErrorResponseBuilder().setCode(500l).setMessage("Error occurred while " +
-                                "publishing the event.").build());
+                        new ErrorResponse.ErrorResponseBuilder().setCode(503l).setMessage("Error occurred due to " +
+                                "unavailability of the publishing service.").build());
             }
         } catch (DataPublisherConfigurationException e) {
             String msg = "Error occurred while getting the Data publisher Service instance.";

--- a/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.api/src/main/java/org/wso2/carbon/mdm/services/android/services/impl/EventReceiverServiceImpl.java
+++ b/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.api/src/main/java/org/wso2/carbon/mdm/services/android/services/impl/EventReceiverServiceImpl.java
@@ -107,8 +107,8 @@ public class EventReceiverServiceImpl implements EventReceiverService {
                 return Response.status(Response.Status.CREATED).entity(message).build();
             } else {
                 log.warn("Error occurred while trying to publish the event. This could be due to unavailability " +
-                        "of the publishing service. Please make sure that analytics server is running and accessible by " +
-                        "this server");
+                        "of the publishing service. Please make sure that analytics server is running and accessible " +
+                        "by this server");
                 throw new UnexpectedServerErrorException(
                         new ErrorResponse.ErrorResponseBuilder().setCode(503l).setMessage("Error occurred due to " +
                                 "unavailability of the publishing service.").build());


### PR DESCRIPTION
## Purpose
This is error occurs when the event publishing causes an error, it does not print any log.

## Goals
Fixing the error printing  in event publishing

## Approach
NA

## User stories
NA

## Release note
NA

## Documentation
NA

## Training
NA

## Certification
NA

## Marketing
NA

## Automation tests
NA

## Security checks
Yes

## Samples
NA

## Related PRs
NA

## Migrations (if applicable)
NA

## Test environment
NA
 
## Learning
NA