### PR TITLE
Adding notification for the user on a Websocket handshake failure

### DIFF
--- a/components/device-types/androidsense-plugin/org.wso2.carbon.device.mgt.iot.androidsense.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android_sense.realtime.analytics-view/analytics-view.hbs
+++ b/components/device-types/androidsense-plugin/org.wso2.carbon.device.mgt.iot.androidsense.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android_sense.realtime.analytics-view/analytics-view.hbs
@@ -59,6 +59,9 @@
     {{/each}}
 
 </div>
+<div class="hide" id="websocker-onerror">
+    Realtime Analytics is not available. Failed to connect to the websocket. Please make sure; '<a style="color: white" href="$webSocketURL">$webSocketURL</a>' is available and re-try again.
+</div>
 
 {{#zone "bottomJs"}}
     {{js "js/moment.min.js"}}

--- a/components/device-types/androidsense-plugin/org.wso2.carbon.device.mgt.iot.androidsense.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android_sense.realtime.analytics-view/public/js/device-stats.js
+++ b/components/device-types/androidsense-plugin/org.wso2.carbon.device.mgt.iot.androidsense.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android_sense.realtime.analytics-view/public/js/device-stats.js
@@ -303,6 +303,15 @@ function connect(target) {
 				}
 			}
 		};
+        ws.onerror = function (event) {
+            var websocketURL = event.currentTarget.url;
+            websocketURL = websocketURL.replace("wss://","https://");
+            var uriParts = websocketURL.split("/");
+            websocketURL = uriParts[0] + "//" + uriParts[2];
+            var errorMsg = $("#websocker-onerror").html();
+            errorMsg = errorMsg.replace(new RegExp('\\$webSocketURL', 'g'), websocketURL);
+            $("#stat-section").html("<div class='alert alert-danger'>" + errorMsg + "</div>");
+        };
 	}
 }
 

--- a/components/device-types/arduino-plugin/org.wso2.carbon.device.mgt.iot.arduino.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.arduino.realtime.analytics-view/analytics-view.hbs
+++ b/components/device-types/arduino-plugin/org.wso2.carbon.device.mgt.iot.arduino.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.arduino.realtime.analytics-view/analytics-view.hbs
@@ -32,6 +32,9 @@
    href="{{@app.context}}/device/{{device.type}}/analytics?deviceId={{device.deviceIdentifier}}&deviceName={{device.name}}">
     <span class="fw-stack"> <i class="fw fw-circle-outline fw-stack-2x"></i> <i class="fw fw-statistics fw-stack-1x"></i> <span class="fw-stack fw-move-right fw-move-bottom"> <i class="fw fw-circle fw-stack-2x fw-stroke"></i> <i class="fw fw-clock fw-stack-1x fw-inverse"></i> </span> </span> View Device Analytics
 </a>
+<div class="hide" id="websocker-onerror">
+    Realtime Analytics is not available. Failed to connect to the websocket. Please make sure; '<a style="color: white" href="$webSocketURL">$webSocketURL</a>' is available and re-try again.
+</div>
 <!-- /statistics -->
 {{#zone "bottomJs"}}
     {{js "js/moment.min.js"}}

--- a/components/device-types/arduino-plugin/org.wso2.carbon.device.mgt.iot.arduino.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.arduino.realtime.analytics-view/public/js/device-stats.js
+++ b/components/device-types/arduino-plugin/org.wso2.carbon.device.mgt.iot.arduino.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.arduino.realtime.analytics-view/public/js/device-stats.js
@@ -96,6 +96,16 @@ function connect(target) {
             chartData.shift();
             graph.update();
         };
+        ws.onerror = function (event) {
+            var websocketURL = event.currentTarget.url;
+            websocketURL = websocketURL.replace("wss://","https://");
+            var uriParts = websocketURL.split("/");
+            websocketURL = uriParts[0] + "//" + uriParts[2];
+            var errorMsg = $("#websocker-onerror").html();
+            errorMsg = errorMsg.replace(new RegExp('\\$webSocketURL', 'g'), websocketURL);
+            $(graph.element).parent().html("<div class='alert alert-danger'>" + errorMsg + "</div>");
+            $(graph.element).hide();
+        };
     }
 }
 

--- a/components/device-types/raspberrypi-plugin/org.wso2.carbon.device.mgt.iot.raspberrypi.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.raspberrypi.realtime.analytics-view/analytics-view.hbs
+++ b/components/device-types/raspberrypi-plugin/org.wso2.carbon.device.mgt.iot.raspberrypi.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.raspberrypi.realtime.analytics-view/analytics-view.hbs
@@ -32,6 +32,9 @@
    href="{{@app.context}}/device/{{device.type}}/analytics?deviceId={{device.deviceIdentifier}}&deviceName={{device.name}}">
     <span class="fw-stack"> <i class="fw fw-circle-outline fw-stack-2x"></i> <i class="fw fw-statistics fw-stack-1x"></i> <span class="fw-stack fw-move-right fw-move-bottom"> <i class="fw fw-circle fw-stack-2x fw-stroke"></i> <i class="fw fw-clock fw-stack-1x fw-inverse"></i> </span> </span> View Device Analytics
 </a>
+<div class="hide" id="websocker-onerror">
+    Realtime Analytics is not available. Failed to connect to the websocket. Please make sure; '<a style="color: white" href="$webSocketURL">$webSocketURL</a>' is available and re-try again.
+</div>
 <!-- /statistics -->
 {{#zone "bottomJs"}}
     {{js "js/moment.min.js"}}

--- a/components/device-types/raspberrypi-plugin/org.wso2.carbon.device.mgt.iot.raspberrypi.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.raspberrypi.realtime.analytics-view/public/js/device-stats.js
+++ b/components/device-types/raspberrypi-plugin/org.wso2.carbon.device.mgt.iot.raspberrypi.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.raspberrypi.realtime.analytics-view/public/js/device-stats.js
@@ -96,6 +96,16 @@ function connect(target) {
             chartData.shift();
             graph.update();
         };
+        ws.onerror = function (event) {
+            var websocketURL = event.currentTarget.url;
+            websocketURL = websocketURL.replace("wss://","https://");
+            var uriParts = websocketURL.split("/");
+            websocketURL = uriParts[0] + "//" + uriParts[2];
+            var errorMsg = $("#websocker-onerror").html();
+            errorMsg = errorMsg.replace(new RegExp('\\$webSocketURL', 'g'), websocketURL);
+            $(graph.element).parent().html("<div class='alert alert-danger'>" + errorMsg + "</div>");
+            $(graph.element).hide();
+        };
     }
 }
 

--- a/components/device-types/virtual-fire-alarm-plugin/org.wso2.carbon.device.mgt.iot.virtualfirealarm.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.virtual_firealarm.realtime.analytics-view/public/js/device-stats.js
+++ b/components/device-types/virtual-fire-alarm-plugin/org.wso2.carbon.device.mgt.iot.virtualfirealarm.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.virtual_firealarm.realtime.analytics-view/public/js/device-stats.js
@@ -99,6 +99,15 @@ function connect(target) {
             chartData.shift();
             graph.update();
         };
+        ws.onerror = function (event) {
+            var websocketURL = event.currentTarget.url;
+            websocketURL = websocketURL.replace("wss://","https://");
+            var uriParts = websocketURL.split("/");
+            websocketURL = uriParts[0] + "//" + uriParts[2];
+            var errorMsg = $("#websocker-onerror").html();
+            errorMsg = errorMsg.replace(new RegExp('\\$webSocketURL', 'g'), websocketURL);
+            $("#div-chart").html("<div class='alert alert-danger'>" + errorMsg + "</div>");
+        };
     }
 }
 


### PR DESCRIPTION
## Purpose
> On the device's realtime analytics page; unless specified and exempted websocket URL endpoint for the IoT Analytics Server will be failed without notifying the user. This PR resolves https://github.com/wso2/product-iots/issues/1659.

## Goals
> Adding notification for the user on a Websocket handshake failure

## Approach
> N/A

## User stories
> N/A

## Release note
> Adding notification for the user on a Websocket handshake failure

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
>  https://github.com/wso2/carbon-device-mgt/pull/1177, https://github.com/wso2/product-iots/pull/1660

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A