### PR TITLE
Correcting wrong logic for retrieving apps in appm

### DIFF
--- a/components/extensions/appm-connector/org.wso2.carbon.appmgt.mdm.osgiconnector/src/main/java/org/wso2/carbon/appmgt/mdm/osgiconnector/ApplicationOperationsImpl.java
+++ b/components/extensions/appm-connector/org.wso2.carbon.appmgt.mdm.osgiconnector/src/main/java/org/wso2/carbon/appmgt/mdm/osgiconnector/ApplicationOperationsImpl.java
@@ -256,11 +256,15 @@ public class ApplicationOperationsImpl implements ApplicationOperations {
                         .getDeviceManagementService(applicationOperationDevice.getTenantId()).
                                 getDevicesOfUser(applicationOperationDevice.getCurrentUser().getUsername());
             } else {
-                deviceList = MDMServiceAPIUtils
-                        .getDeviceManagementService(applicationOperationDevice.getTenantId()).
-                                getDevicesOfUser(applicationOperationDevice.getCurrentUser().getUsername(),
-                                        applicationOperationDevice.getPlatform());
-            }
+				deviceList = MDMServiceAPIUtils
+						.getDeviceManagementService(applicationOperationDevice.getTenantId()).
+								getDevicesOfUser(applicationOperationDevice.getCurrentUser().getUsername(),
+										MDMAppConstants.ANDROID);
+				deviceList.addAll(MDMServiceAPIUtils
+						.getDeviceManagementService(applicationOperationDevice.getTenantId()).
+								getDevicesOfUser(applicationOperationDevice.getCurrentUser().getUsername(),
+										MDMAppConstants.IOS));
+			}
             devices = new ArrayList<>(deviceList.size());
 			if(log.isDebugEnabled()){
 				log.debug("device list got from mdm "+ deviceList.toString());

--- a/components/extensions/appm-connector/org.wso2.carbon.appmgt.mdm.osgiconnector/src/main/java/org/wso2/carbon/appmgt/mdm/osgiconnector/ApplicationOperationsImpl.java
+++ b/components/extensions/appm-connector/org.wso2.carbon.appmgt.mdm.osgiconnector/src/main/java/org/wso2/carbon/appmgt/mdm/osgiconnector/ApplicationOperationsImpl.java
@@ -261,10 +261,10 @@ public class ApplicationOperationsImpl implements ApplicationOperations {
 			} else {
 				deviceList = deviceManagementService.
 						getDevicesOfUser(username,
-								MDMAppConstants.ANDROID);
+						                 MDMAppConstants.ANDROID);
 				deviceList.addAll(deviceManagementService.
 						getDevicesOfUser(username,
-								MDMAppConstants.IOS));
+						                 MDMAppConstants.IOS));
 			}
 			devices = new ArrayList<>(deviceList.size());
 			if(log.isDebugEnabled()){

--- a/components/extensions/appm-connector/org.wso2.carbon.appmgt.mdm.osgiconnector/src/main/java/org/wso2/carbon/appmgt/mdm/osgiconnector/ApplicationOperationsImpl.java
+++ b/components/extensions/appm-connector/org.wso2.carbon.appmgt.mdm.osgiconnector/src/main/java/org/wso2/carbon/appmgt/mdm/osgiconnector/ApplicationOperationsImpl.java
@@ -44,6 +44,7 @@ import org.wso2.carbon.device.mgt.common.operation.mgt.Operation;
 import org.wso2.carbon.appmgt.mobile.utils.User;
 
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.device.mgt.core.service.DeviceManagementProviderService;
 import org.wso2.carbon.registry.api.Resource;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.registry.core.session.UserRegistry;
@@ -250,22 +251,22 @@ public class ApplicationOperationsImpl implements ApplicationOperations {
 		List<Device> devices;
 		List<org.wso2.carbon.device.mgt.common.Device> deviceList = null;
 		try {
-            if (MDMAppConstants.WEBAPP.equals
-                    (applicationOperationDevice.getPlatform())) {
-                deviceList = MDMServiceAPIUtils
-                        .getDeviceManagementService(applicationOperationDevice.getTenantId()).
-                                getDevicesOfUser(applicationOperationDevice.getCurrentUser().getUsername());
-            } else {
-				deviceList = MDMServiceAPIUtils
-						.getDeviceManagementService(applicationOperationDevice.getTenantId()).
-								getDevicesOfUser(applicationOperationDevice.getCurrentUser().getUsername(),
-										MDMAppConstants.ANDROID);
-				deviceList.addAll(MDMServiceAPIUtils
-						.getDeviceManagementService(applicationOperationDevice.getTenantId()).
-								getDevicesOfUser(applicationOperationDevice.getCurrentUser().getUsername(),
-										MDMAppConstants.IOS));
+			DeviceManagementProviderService deviceManagementService = MDMServiceAPIUtils
+					.getDeviceManagementService(applicationOperationDevice.getTenantId());
+			final String username = applicationOperationDevice.getCurrentUser().getUsername();
+			if (MDMAppConstants.WEBAPP.equals
+					(applicationOperationDevice.getPlatform())) {
+				deviceList = deviceManagementService.
+						getDevicesOfUser(username);
+			} else {
+				deviceList = deviceManagementService.
+						getDevicesOfUser(username,
+								MDMAppConstants.ANDROID);
+				deviceList.addAll(deviceManagementService.
+						getDevicesOfUser(username,
+								MDMAppConstants.IOS));
 			}
-            devices = new ArrayList<>(deviceList.size());
+			devices = new ArrayList<>(deviceList.size());
 			if(log.isDebugEnabled()){
 				log.debug("device list got from mdm "+ deviceList.toString());
 			}


### PR DESCRIPTION
## Purpose
> Rectifying error stack trace thrown when trying to accessing APPM store

## Goals
> Removing wrong logic for retrieving devices for displaying in APPM store

## Approach
> When loading the app store initially applicationOperationDevice.getPlatform() is null, therefore trying to load devices based on a null platform, returns an error. This behavior is wrong. Given that, APPM store only displays iOS and ANDROID, applications. Devices relevant to said platforms need to be loaded. Code changes have been done to draw android and ios devices selectively.

## User stories
> N/A

## Release note
> Rectifying error stack trace thrown when trying to accessing APPM store

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/a
 
## Learning
> N/A.