### PR TITLE
Add device remote controlling for tenants

### DIFF
--- a/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.device-view/device-view.js
+++ b/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.device-view/device-view.js
@@ -189,14 +189,19 @@ function onRequest(context) {
         var jwtService = carbonServer.osgiService('org.wso2.carbon.identity.jwt.client.extension.service.JWTClientManagerService');
         var jwtClient = jwtService.getJWTClient();
         var encodedClientKeys = session.get(constants["ENCODED_TENANT_BASED_WEB_SOCKET_CLIENT_CREDENTIALS"]);
+        var tokenPair = null;
         var token = "";
         if (encodedClientKeys) {
             var tokenUtil = require("/app/modules/oauth/token-handler-utils.js")["utils"];
             var resp = tokenUtil.decode(encodedClientKeys).split(":");
-            var tokenPair = jwtClient.getAccessToken(resp[0], resp[1], context.user.username,"default", {});
+            if (context.user.domain == "carbon.super") {
+                tokenPair = jwtClient.getAccessToken(resp[0], resp[1], context.user.username,"default", {});
+            } else {
+                tokenPair = jwtClient.getAccessToken(resp[0], resp[1], context.user.username + "@" + context.user.domain,"default", {});
+            }
             if (tokenPair) {
                 token = tokenPair.accessToken;
-                }
+            }
         }
         remoteSessionEndpoint = remoteSessionEndpoint + "/remote/session/clients/" + deviceType + "/" + deviceId +
         "?websocketToken=" + token


### PR DESCRIPTION
## Purpose
> The purpose of this PR is to fix web socket connecting issue in the remote control feature for tenant mode.

## Goals
> In order to connect to the WebSocket, it is required to provide valid access token. When getting access token, in the tenant mode it is required to pass tenant domain along with the context of the username. Hence, in the tenant mode passed a valid token when connecting to the WebSocket.

## Approach
> N/A

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A