### PR TITLE
Update documentation anchor links

### DIFF
--- a/components/device-types/androidsense-plugin/org.wso2.carbon.device.mgt.iot.androidsense.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android_sense.type-view/type-view.hbs
+++ b/components/device-types/androidsense-plugin/org.wso2.carbon.device.mgt.iot.androidsense.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android_sense.type-view/type-view.hbs
@@ -41,7 +41,7 @@
     <a href="#" class="download-link btn-operations"><i class="fw fw-mobile fw-inverse fw-lg add-margin-1x"></i> Enroll Device</a>
     <a href="{{hostName}}{{@unit.publicUri}}/asset/androidsense.apk" class="btn-operations"><i class="fw fw-download fw-inverse fw-lg add-margin-1x"></i> Download APK</a>
     <a href="javascript:toggleEmailInvite()" class="btn-operations"><i class="fw fw-mail fw-inverse fw-lg add-margin-1x"></i> Invite by Email</a>
-    <p class="doc-link">Click <a href="https://docs.wso2.com/display/IoTS310/Android+Sense"
+    <p class="doc-link">Click <a href="https://docs.wso2.com/display/IoTS320/Android+Sense"
                                  target="_blank">[ here ]</a> for latest instructions and
         troubleshooting.</p>
 

--- a/components/device-types/arduino-plugin/org.wso2.carbon.device.mgt.iot.arduino.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.arduino.type-view/type-view.hbs
+++ b/components/device-types/arduino-plugin/org.wso2.carbon.device.mgt.iot.arduino.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.arduino.type-view/type-view.hbs
@@ -64,7 +64,7 @@
     <a href="#" class="download-link btn-operations">
         <i class="fw fw-download add-margin-1x"></i>Download Sketch
     </a>
-    <p class="doc-link">Click <a href="https://docs.wso2.com/display/IoTS310/Arduino"
+    <p class="doc-link">Click <a href="https://docs.wso2.com/display/IoTS320/Arduino"
                                  target="_blank">here</a> for latest instructions and
         troubleshooting.</p>
     <div id="download-device-modal-content" class="hide">

--- a/components/device-types/raspberrypi-plugin/org.wso2.carbon.device.mgt.iot.raspberrypi.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.raspberrypi.type-view/type-view.hbs
+++ b/components/device-types/raspberrypi-plugin/org.wso2.carbon.device.mgt.iot.raspberrypi.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.raspberrypi.type-view/type-view.hbs
@@ -62,7 +62,7 @@
         <i class="fw fw-download add-margin-1x"></i>Download Agent
     </a>
 
-    <p class="doc-link">Click <a href="https://docs.wso2.com/display/IoTS310/Raspberry+Pi"
+    <p class="doc-link">Click <a href="https://docs.wso2.com/display/IoTS320/Raspberry+Pi"
                                  target="_blank">here</a> for latest instructions and
         troubleshooting.</p>
     <div id="download-device-modal-content" class="hide">

--- a/components/device-types/virtual-fire-alarm-plugin/org.wso2.carbon.device.mgt.iot.virtualfirealarm.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.virtual_firealarm.type-view/type-view.hbs
+++ b/components/device-types/virtual-fire-alarm-plugin/org.wso2.carbon.device.mgt.iot.virtualfirealarm.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.virtual_firealarm.type-view/type-view.hbs
@@ -57,7 +57,7 @@
         <a href="javascript:artifactUpload()" class="btn-operations"><i class="fw fw-upload fw-inverse fw-lg add-margin-1x"></i> Deploy Analytics Artifacts</a>
     {{/if}}
 
-    <p class="doc-link">Click <a href="https://docs.wso2.com/display/IoTS310/Enterprise+IoT+solution"
+    <p class="doc-link">Click <a href="https://docs.wso2.com/display/IoTS320/Enterprise+IoT+solution"
                                   target="_blank">[ here ]</a> for the latest instructions and troubleshooting tips.
     </p>
     <div id="download-device-modal-content" class="hide">

--- a/components/extensions/siddhi-extensions/org.wso2.gpl.siddhi.extension.geo.script/src/main/resources/scripts/gpl-siddhi-geo-extention/org.wso2.gpl.siddhi.extension.geo.feature/pom.xml
+++ b/components/extensions/siddhi-extensions/org.wso2.gpl.siddhi.extension.geo.script/src/main/resources/scripts/gpl-siddhi-geo-extention/org.wso2.gpl.siddhi.extension.geo.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.gpl.siddhi.extensions</groupId>
         <artifactId>siddhi-extension-gpl-geo-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.2.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/extensions/siddhi-extensions/org.wso2.gpl.siddhi.extension.geo.script/src/main/resources/scripts/gpl-siddhi-geo-extention/pom.xml
+++ b/components/extensions/siddhi-extensions/org.wso2.gpl.siddhi.extension.geo.script/src/main/resources/scripts/gpl-siddhi-geo-extention/pom.xml
@@ -31,7 +31,7 @@
 
     <groupId>org.wso2.gpl.siddhi.extensions</groupId>
     <artifactId>siddhi-extension-gpl-geo-parent</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <packaging>pom</packaging>
     <name>Siddhi Extension - Geo</name>
     <description>WSO2 Siddhi Geo Extension</description>

--- a/components/extensions/siddhi-extensions/org.wso2.gpl.siddhi.extension.geo.script/src/main/resources/scripts/siddhi-geo-extention-deployer.xml
+++ b/components/extensions/siddhi-extensions/org.wso2.gpl.siddhi.extension.geo.script/src/main/resources/scripts/siddhi-geo-extention-deployer.xml
@@ -31,7 +31,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.iot.devicemgt-plugins</groupId>
     <artifactId>analytics-scripts</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <packaging>pom</packaging>
     <name>Executing Analytics Scripts</name>
     <url>http://wso2.org</url>
@@ -193,7 +193,7 @@
         </repository>
     </repositories>
     <properties>
-        <org.wso2.iot.devicemgt-plugins.gpl.siddhi.extensions.version>3.1.0-SNAPSHOT</org.wso2.iot.devicemgt-plugins.gpl.siddhi.extensions.version>
+        <org.wso2.iot.devicemgt-plugins.gpl.siddhi.extensions.version>3.2.0</org.wso2.iot.devicemgt-plugins.gpl.siddhi.extensions.version>
         <siddhi-gpl-execution-geo-feature.version>3.2.0</siddhi-gpl-execution-geo-feature.version>
     </properties>
 </project>

--- a/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.type-view/type-view.hbs
+++ b/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.type-view/type-view.hbs
@@ -63,9 +63,9 @@
     {{else}}
         <p class="doc-link text-center">Need help? Read <a
             {{#if isVirtual}}
-                href="https://docs.wso2.com/display/IoTS310/Android+Virtual+Device"
+                href="https://docs.wso2.com/display/IoTS320/Android+Virtual+Device"
             {{else}}
-                href="https://docs.wso2.com/display/IoTS310/Android"
+                href="https://docs.wso2.com/display/IoTS320/Android"
             {{/if}}
              target="_blank">WSO2 IoT Server documentation.</a></p>
     {{/if}}


### PR DESCRIPTION
## Purpose
> Updating documentation anchor links in UIs. Resolves https://github.com/wso2/product-iots/issues/1694

## Goals
> Updating documentation anchor links in UIs. 

## Approach
> Updating documentation anchor links in UIs. 

## User stories
> N/A

## Release note
> Updating documentation anchor links in UIs. 

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> https://github.com/wso2/carbon-device-mgt/pull/1201

## Migrations (if applicable)
> N/A

## Test environment
> Apache Maven 3.5.2
Maven home: /usr/local/Cellar/maven/3.5.2/libexec
Java version: 1.8.0_152, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk1.8.0_152.jdk/Contents/Home/jre
Default locale: en_LK, platform encoding: UTF-8
OS name: "mac os x", version: "10.13.3", arch: "x86_64", family: "mac"
 
## Learning
> N/A