### PR TITLE
Version bump of carbon kernel and identity components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1181,7 +1181,7 @@
         <wso2.maven.compiler.target>1.7</wso2.maven.compiler.target>
 
         <!--Carbon kernel versions-->
-        <carbon.kernel.version>4.4.17</carbon.kernel.version>
+        <carbon.kernel.version>4.4.24</carbon.kernel.version>
         <carbon.kernel.version.range>[4.4.0, 4.5.0)</carbon.kernel.version.range>
 
         <carbon.p2.plugin.version>1.5.4</carbon.p2.plugin.version>
@@ -1225,28 +1225,28 @@
         <carbon.devicemgt.plugins.version>4.0.137-SNAPSHOT</carbon.devicemgt.plugins.version>
 
         <!-- Carbon Commons -->
-        <carbon.commons.version>4.4.8</carbon.commons.version>
+        <carbon.commons.version>4.6.21</carbon.commons.version>
 
         <!-- Carbon Deployment -->
         <carbon.deployment.version>4.7.2</carbon.deployment.version>
 
         <!-- Carbon Identity -->
-        <carbon.identity.framework.version>5.6.89</carbon.identity.framework.version>
-        <identity.inbound.auth.oauth.version>5.3.1</identity.inbound.auth.oauth.version>
+        <carbon.identity.framework.version>5.11.120</carbon.identity.framework.version>
+        <identity.inbound.auth.oauth.version>5.6.51</identity.inbound.auth.oauth.version>
         <carbon.identity.version.range>[5.2.0, 6.0.0)</carbon.identity.version.range>
-        <identity.carbon.auth.jwt.version>5.1.2</identity.carbon.auth.jwt.version>
+        <identity.carbon.auth.jwt.version>5.1.3</identity.carbon.auth.jwt.version>
 
         <!-- Carbon Multi-tenancy -->
-        <carbon.multitenancy.version>4.6.1</carbon.multitenancy.version>
+        <carbon.multitenancy.version>4.6.8</carbon.multitenancy.version>
 
         <!-- Carbon Registry -->
-        <carbon.registry.version>4.6.8</carbon.registry.version>
+        <carbon.registry.version>4.6.28</carbon.registry.version>
 
         <!-- Carbon Governance -->
         <carbon.governance.version>4.7.8</carbon.governance.version>
 
         <!-- Carbon API Management -->
-        <carbon.api.mgt.version>6.1.109</carbon.api.mgt.version>
+        <carbon.api.mgt.version>6.2.146</carbon.api.mgt.version>
 
         <!-- XMPP/MQTT Version -->
         <smack.wso2.version>3.0.4.wso2v1</smack.wso2.version>


### PR DESCRIPTION
This commit upgrade the below listed components to the mentioned versions,
carbon.kernel - 4.4.24
carbon.identity.framework  - 5.11.120
identity.inbound.auth.oauth - 5.6.51
carbon.multitenancy - 4.6.8
carbon.governance - 4.7.23
carbon.commons - 4.6.0
carbon.api.mgt - 6.2.146
carbon.registry - 4.6.28

## Purpose
> Version upgrade to 
carbon.kernel - 4.4.24
carbon.identity.framework  - 5.11.120
identity.inbound.auth.oauth - 5.6.51
carbon.multitenancy - 4.6.8
carbon.governance - 4.7.23
carbon.commons - 4.6.0
carbon.api.mgt - 6.2.146
carbon.registry - 4.6.28

## Goals
> To apply the latest platform level fixed and security fixes available.

## Approach
> upgrade the related component versions

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A