### PR TITLE
Make remote control feature mutual ssl compatible

### DIFF
--- a/components/extensions/remote-session-extension/org.wso2.carbon.device.mgt.extensions.remote.session/src/main/java/org/wso2/carbon/device/mgt/extensions/remote.session/RemoteSessionManagementServiceImpl.java
+++ b/components/extensions/remote-session-extension/org.wso2.carbon.device.mgt.extensions.remote.session/src/main/java/org/wso2/carbon/device/mgt/extensions/remote.session/RemoteSessionManagementServiceImpl.java
@@ -73,6 +73,7 @@ public class RemoteSessionManagementServiceImpl implements RemoteSessionManageme
         sessionQueryParamList.add(session.getQueryString());
         sessionQueryParam.put(RemoteSessionConstants.QUERY_STRING, sessionQueryParamList);
 
+        // if session initiated using operation id means request came from device.
         if (operationId == null) {
             // Validate the token
             OAuthAuthenticator oAuthAuthenticator = RemoteSessionManagementDataHolder.getInstance().getOauthAuthenticator();
@@ -102,16 +103,8 @@ public class RemoteSessionManagementServiceImpl implements RemoteSessionManageme
                                     .getMaxMessageBufferSize());
                             session.setMaxIdleTimeout(RemoteSessionManagementDataHolder.getInstance().getMaxIdleTimeout());
 
-                            // if session initiated using operation id means request came from device
-//                            if (operationId != null) {
-//                                // create new device session
-//                                initializeDeviceSession(session, authenticationInfo.getTenantDomain(), deviceType, deviceId,
-//                                        operationId);
-//                            } else {
-                                // create new client session
-                                initializeClientSession(session, authenticationInfo.getTenantDomain(), deviceType,
-                                        deviceId);
-//                            }
+                            initializeClientSession(session, authenticationInfo.getTenantDomain(), deviceType, deviceId);
+
                             log.info("Current remote sessions count: " + RemoteSessionManagementDataHolder.getInstance()
                                     .getSessionMap().size());
 
@@ -145,11 +138,11 @@ public class RemoteSessionManagementServiceImpl implements RemoteSessionManageme
             session.setMaxIdleTimeout(RemoteSessionManagementDataHolder.getInstance().getMaxIdleTimeout());
             String uuid = session.getQueryString();
 
-            if(uuid != null && uuid.isEmpty()){
+            if (uuid != null && uuid.isEmpty()) {
                 log.error("Could not find a UUID related to the remote session");
             } else {
                 String tenantDomain = RemoteSessionManagementDataHolder.getInstance().getUuidToTenantMap().remove(uuid);
-                if(tenantDomain == null || tenantDomain.isEmpty()){
+                if (tenantDomain == null || tenantDomain.isEmpty()) {
                     log.error("Invalid UUID, could not create the remote session");
                 } else {
                     // create new device session
@@ -304,10 +297,11 @@ public class RemoteSessionManagementServiceImpl implements RemoteSessionManageme
                 JSONObject payload = new JSONObject();
                 payload.put("serverUrl", RemoteSessionManagementDataHolder.getInstance().getServerUrl());
                 payload.put("uuidToValidateDevice", uuidToValidateDevice);
-                String uuidToTenantMap = RemoteSessionManagementDataHolder.getInstance().getUuidToTenantMap
-                        ().putIfAbsent(uuidToValidateDevice, tenantDomain);
+                RemoteSessionManagementDataHolder.getInstance().getUuidToTenantMap
+                        ().put(uuidToValidateDevice, tenantDomain);
                 if (log.isDebugEnabled()) {
-                    log.debug("UUID " + uuidToTenantMap + " is generated against the tenant : " + tenantDomain);
+                    log.debug("UUID " + uuidToValidateDevice + " is generated against the tenant : " +
+                            RemoteSessionManagementDataHolder.getInstance().getUuidToTenantMap().get(uuidToValidateDevice));
                 }
                 operation.setPayLoad(payload.toString());
                 String date = new SimpleDateFormat(RemoteSessionConstants.DATE_FORMAT_NOW).format(new Date());

--- a/components/extensions/remote-session-extension/org.wso2.carbon.device.mgt.extensions.remote.session/src/main/java/org/wso2/carbon/device/mgt/extensions/remote.session/dto/RemoteSession.java
+++ b/components/extensions/remote-session-extension/org.wso2.carbon.device.mgt.extensions.remote.session/src/main/java/org/wso2/carbon/device/mgt/extensions/remote.session/dto/RemoteSession.java
@@ -34,7 +34,11 @@ import java.nio.ByteBuffer;
 public class RemoteSession {
 
     private static final Log log = LogFactory.getLog(RemoteSession.class);
-    private String tenantDomain, operationId, deviceType, deviceId;
+    private String tenantDomain;
+    private String operationId;
+    private String deviceType;
+    private String deviceId;
+    private String uuidToValidateDevice;
     private long lastMessageTimeStamp = System.currentTimeMillis();
     private RemoteSession peerSession;
     private Session mySession;
@@ -45,12 +49,13 @@ public class RemoteSession {
     private RemoteSessionConstants.CONNECTION_TYPE connectionType;
 
     public RemoteSession(Session session, String tenantDomain, String deviceType, String deviceId,
-                         RemoteSessionConstants.CONNECTION_TYPE connectionType) {
+                         RemoteSessionConstants.CONNECTION_TYPE connectionType, String uuidToValidateDevice) {
         this.mySession = session;
         this.deviceType = deviceType;
         this.deviceId = deviceId;
         this.tenantDomain = tenantDomain;
         this.connectionType = connectionType;
+        this.uuidToValidateDevice = uuidToValidateDevice;
         maxMessagesPerSecond = RemoteSessionManagementDataHolder.getInstance().getMaxMessagesPerSecond();
         messageAllowance = maxMessagesPerSecond;
         messageRatePerSecond = (double) maxMessagesPerSecond / 1000;
@@ -107,6 +112,10 @@ public class RemoteSession {
         } else {
             return true;
         }
+    }
+
+    public String getUuidToValidateDevice() {
+        return uuidToValidateDevice;
     }
 
     public Session getMySession() {

--- a/components/extensions/remote-session-extension/org.wso2.carbon.device.mgt.extensions.remote.session/src/main/java/org/wso2/carbon/device/mgt/extensions/remote.session/internal/RemoteSessionManagementDataHolder.java
+++ b/components/extensions/remote-session-extension/org.wso2.carbon.device.mgt.extensions.remote.session/src/main/java/org/wso2/carbon/device/mgt/extensions/remote.session/internal/RemoteSessionManagementDataHolder.java
@@ -43,6 +43,11 @@ public class RemoteSessionManagementDataHolder {
     private OAuthAuthenticator oAuthAuthenticator;
     private Map<String, RemoteSession> activeDeviceClientSessionMap = new ConcurrentHashMap<String, RemoteSession>();
     private Map<String, RemoteSession> sessionMap = new ConcurrentHashMap<String, RemoteSession>();
+    private Map<String, String> uuidToTenantMap = new ConcurrentHashMap<>();
+
+    public Map<String, String> getUuidToTenantMap() {
+        return uuidToTenantMap;
+    }
 
     public static RemoteSessionManagementDataHolder getInstance() {
         return thisInstance;


### PR DESCRIPTION
## Purpose
> When an Android device is enrolled to IoT server using mutual-ssl remote session creation fails. Device screen sharer, adb command executer and to Logcat viewer aren't working. This PR will address this issue. Resolves #186

## Goals
> To enable remote control feature when an Android device is enrolled using mutual-ssl. This PR will add the relevant server side fixes. 

## Approach
> Previously this operation logic was handled via the access tokens. The device has to call the server with the access token it receives when enrolling to the server. In a situation where the device is enrolled under mutual-ssl, there won't be any access tokens to establish the socket connection. Thus the enrollment fails. With this change there is a new UUID introduced instead of the access token. UUID will be initially generated by the server and sent to the securely enrolled device. And then the device will call back to the server with this UUID to establish the web-socket connection.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> https://github.com/wso2/cdmf-agent-android/pull/187

## Migrations (if applicable)
> N/A

## Test environment
> IoT Server v3.3.1 and Android Agent v3.1.34 above (excludes v3.1.34)
 
## Learning
> N/A