### PR TITLE
Improve default operations loading

### DIFF
--- a/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.device-view/device-view.hbs
+++ b/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.device-view/device-view.hbs
@@ -12,11 +12,13 @@
 
         {{#zone "device-details-header"}}
             <h1 class="device-id"
-            data-deviceid="{{device.deviceIdentifier}}"
-            data-type="{{device.type}}"
-            data-ownership="{{device.ownership}}"
-            data-owner="{{device.owner}}"
-            data-status="{{device.status}}">
+                data-deviceid="{{device.deviceIdentifier}}"
+                data-type="{{device.type}}"
+                data-ownership="{{device.ownership}}"
+                data-owner="{{device.owner}}"
+                data-status="{{device.status}}"
+                data-deviceinfoservice="{{device.deviceInfoServiceAPI}}"
+                data-devicelocationservice="{{device.deviceLocationServiceAPI}}">
             {{device.owner}}'s {{device.name}}
               <a id="device-info-tooltip" href="#" data-toggle="tooltip" title="Device Identifier: {{device.deviceIdentifier}}
               Firmware Build Date: {{device.osBuildDate}}

--- a/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.device-view/device-view.js
+++ b/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.device-view/device-view.js
@@ -24,19 +24,28 @@ function onRequest(context) {
     var deviceViewData = {};
     var devicemgtProps = require("/app/modules/conf-reader/main.js")["conf"];
     var carbonServer = require("carbon").server;
-    var constants = require("/app/modules/constants.js")
+    var constants = require("/app/modules/constants.js");
 
     if (deviceType && deviceId) {
         var deviceModule = require("/app/modules/business-controllers/device.js")["deviceModule"];
         var response = deviceModule.viewDevice(deviceType, deviceId, owner);
-        if (response["status"] == "success") {
+        if (response["status"] === "success") {
             deviceViewData["deviceFound"] = true;
             deviceViewData["isAuthorized"] = true;
 
             var filteredDeviceData = response["content"];
 
-// creating deviceView information model from filtered device data
+            // creating deviceView information model from filtered device data
             var viewModel = {};
+            var deviceInfoServiceAPI = devicemgtProps["deviceInfoServiceAPI"];
+            var deviceLocationServiceAPI = devicemgtProps["deviceLocationServiceAPI"];
+
+            if (deviceInfoServiceAPI){
+              viewModel["deviceInfoServiceAPI"] = deviceInfoServiceAPI.replace("%device-type%", deviceType)
+            }
+            if (deviceLocationServiceAPI){
+              viewModel['deviceLocationServiceAPI'] = deviceLocationServiceAPI.replace("%device-type%", deviceType)
+            }
             if (filteredDeviceData["type"]) {
                 viewModel["type"] = filteredDeviceData["type"];
                 viewModel.isNotWindows = true;

--- a/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.device-view/public/js/device-detail.js
+++ b/components/mobile-plugins/android-plugin/org.wso2.carbon.device.mgt.mobile.android.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.android.device-view/public/js/device-detail.js
@@ -26,46 +26,42 @@ var InitiateViewOption = null;
     var devStatus = deviceId.data("status");
     var payload = [deviceIdentifier];
     var operationTable;
-    var serviceUrl;
-    var serviceUrlLocal = "/api/device-mgt/android/v1.0/admin/devices/location";
 
-    if (deviceType == "ios") {
-        serviceUrl = "/ios/operation/deviceinfo";
-    } else if (deviceType == "android") {
-        //var serviceUrl = "/mdm-android-agent/operation/device-info";
-        serviceUrl = "/api/device-mgt/android/v1.0/admin/devices/info";
-        serviceUrlLocal = "/api/device-mgt/android/v1.0/admin/devices/location";
-    }
-    if (serviceUrl && ("REMOVED" !== devStatus)) {
+    if ("REMOVED" !== devStatus) {
+      var deviceInfoServiceAPI = deviceId.data("deviceinfoservice");
+      var deviceLocationServiceAPI = deviceId.data("devicelocationservice");
+      if (deviceInfoServiceAPI) {
         invokerUtil.post(
-            serviceUrl,
-            payload,
-            // success-callback
-            function () {
-                $(".panel-body").show();
-            },
-            // error-callback
-            function () {
-                var defaultInnerHTML =
-                    "<br><p class='fw-warning'>Device data may not have been updated. Please refresh to try again.<p>";
-                $(".panel-body").append(defaultInnerHTML);
-            }
+          deviceInfoServiceAPI,
+          payload,
+          // success-callback
+          function () {
+            $(".panel-body").show();
+          },
+          // error-callback
+          function () {
+            var defaultInnerHTML =
+              "<br><p class='fw-warning'>Device data may not have been updated. Please refresh to try again.<p>";
+            $(".panel-body").append(defaultInnerHTML);
+          }
         );
+      }
+      if (deviceLocationServiceAPI) {
         invokerUtil.post(
-            serviceUrlLocal,
-            payload,
-            // success-callback
-            function () {
-                $(".panel-body").show();
-            },
-            // error-callback
-            function () {
-                var defaultInnerHTML =
-                    "<br><p class='fw-warning'>Device data may not have been updated. Please refresh to try again.<p>";
-                $(".panel-body").append(defaultInnerHTML);
-            }
+          deviceLocationServiceAPI,
+          payload,
+          // success-callback
+          function () {
+            $(".panel-body").show();
+          },
+          // error-callback
+          function () {
+            var defaultInnerHTML =
+              "<br><p class='fw-warning'>Device data may not have been updated. Please refresh to try again.<p>";
+            $(".panel-body").append(defaultInnerHTML);
+          }
         );
-
+      }
     }
 
     $(".media.tab-responsive [data-toggle=tab]").on("shown.bs.tab", function (e) {

--- a/components/mobile-plugins/windows-plugin/org.wso2.carbon.device.mgt.mobile.windows.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.windows.device-view/device-view.hbs
+++ b/components/mobile-plugins/windows-plugin/org.wso2.carbon.device.mgt.mobile.windows.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.windows.device-view/device-view.hbs
@@ -11,11 +11,13 @@
 
         {{#zone "device-details-header"}}
             <h1 class="device-id"
-            data-deviceid="{{device.deviceIdentifier}}"
-            data-type="{{device.type}}"
-            data-ownership="{{device.ownership}}"
-            data-owner="{{device.owner}}"
-            data-status="{{device.status}}">
+                data-deviceid="{{device.deviceIdentifier}}"
+                data-type="{{device.type}}"
+                data-ownership="{{device.ownership}}"
+                data-owner="{{device.owner}}"
+                data-status="{{device.status}}"
+                data-deviceinfoservice="{{device.deviceInfoServiceAPI}}"
+                data-devicelocationservice="{{device.deviceLocationServiceAPI}}">
             {{device.owner}}'s {{device.name}}
             </h1>
             <a id="device-info-tooltip" href="#" data-toggle="tooltip" title="Device Identifier: {{device.deviceIdentifier}}

--- a/components/mobile-plugins/windows-plugin/org.wso2.carbon.device.mgt.mobile.windows.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.windows.device-view/device-view.js
+++ b/components/mobile-plugins/windows-plugin/org.wso2.carbon.device.mgt.mobile.windows.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.windows.device-view/device-view.js
@@ -26,7 +26,7 @@ function onRequest(context) {
     if (deviceType && deviceId) {
         var deviceModule = require("/app/modules/business-controllers/device.js")["deviceModule"];
         var response = deviceModule.viewDevice(deviceType, deviceId, owner);
-        if (response["status"] == "success") {
+        if (response["status"] === "success") {
             deviceViewData["deviceFound"] = true;
             deviceViewData["isAuthorized"] = true;
 
@@ -34,6 +34,15 @@ function onRequest(context) {
 
             // creating deviceView information model from filtered device data
             var viewModel = {};
+            var deviceInfoServiceAPI = devicemgtProps["deviceInfoServiceAPI"];
+            var deviceLocationServiceAPI = devicemgtProps["deviceLocationServiceAPI"];
+
+            if (deviceInfoServiceAPI){
+              viewModel["deviceInfoServiceAPI"] = deviceInfoServiceAPI.replace("%device-type%", deviceType)
+            }
+            if (deviceLocationServiceAPI){
+              viewModel['deviceLocationServiceAPI'] = deviceLocationServiceAPI.replace("%device-type%", deviceType)
+            }
             if (filteredDeviceData["type"]) {
                 viewModel["type"] = filteredDeviceData["type"];
                 viewModel.isNotWindows = true;

--- a/components/mobile-plugins/windows-plugin/org.wso2.carbon.device.mgt.mobile.windows.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.windows.device-view/public/js/device-detail.js
+++ b/components/mobile-plugins/windows-plugin/org.wso2.carbon.device.mgt.mobile.windows.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.windows.device-view/public/js/device-detail.js
@@ -26,30 +26,42 @@ var InitiateViewOption = null;
     var devStatus = deviceId.data("status");
     var payload = [deviceIdentifier];
     var operationTable;
-    var serviceUrl;
 
-    if (deviceType == "ios") {
-        serviceUrl = "/ios/operation/deviceinfo";
-    } else if (deviceType == "android") {
-        //var serviceUrl = "/mdm-android-agent/operation/device-info";
-        serviceUrl = "/api/device-mgt/android/v1.0/admin/devices/info";
-    }
-
-    if (serviceUrl && ("REMOVED" !== devStatus)) {
+    if ("REMOVED" !== devStatus) {
+      var deviceInfoServiceAPI = deviceId.data("deviceinfoservice");
+      var deviceLocationServiceAPI = deviceId.data("devicelocationservice");
+      if (deviceInfoServiceAPI) {
         invokerUtil.post(
-            serviceUrl,
-            payload,
-            // success-callback
-            function () {
-                $(".panel-body").show();
-            },
-            // error-callback
-            function () {
-                var defaultInnerHTML =
-                    "<br><p class='fw-warning'>Device data may not have been updated. Please refresh to try again.<p>";
-                $(".panel-body").append(defaultInnerHTML);
-            }
+          deviceInfoServiceAPI,
+          payload,
+          // success-callback
+          function () {
+            $(".panel-body").show();
+          },
+          // error-callback
+          function () {
+            var defaultInnerHTML =
+              "<br><p class='fw-warning'>Device data may not have been updated. Please refresh to try again.<p>";
+            $(".panel-body").append(defaultInnerHTML);
+          }
         );
+      }
+      if (deviceLocationServiceAPI) {
+        invokerUtil.post(
+          deviceLocationServiceAPI,
+          payload,
+          // success-callback
+          function () {
+            $(".panel-body").show();
+          },
+          // error-callback
+          function () {
+            var defaultInnerHTML =
+              "<br><p class='fw-warning'>Device data may not have been updated. Please refresh to try again.<p>";
+            $(".panel-body").append(defaultInnerHTML);
+          }
+        );
+      }
     }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -1230,7 +1230,7 @@
         <javax.ws.rs.version>1.1.1</javax.ws.rs.version>
 
         <!-- Carbon Device Management -->
-        <carbon.devicemgt.version>3.1.47</carbon.devicemgt.version>
+        <carbon.devicemgt.version>3.1.48</carbon.devicemgt.version>
         <carbon.devicemgt.version.range>[3.1.0, 4.0.0)</carbon.devicemgt.version.range>
 
         <!-- Carbon App Management -->


### PR DESCRIPTION
## Purpose
> The purpose of this PR is to improve default operation loading functionality.

## Goals
> When loading device details page, default operations are loaded always. With this improvement, default operations will be loaded if API paths are defined in the config.json

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK - Oracle 1.8
> OS - UBUNTU 18.04
> Browser - Chrome